### PR TITLE
click on county redirects to reps

### DIFF
--- a/app/javascript/packs/state_map_utils.js
+++ b/app/javascript/packs/state_map_utils.js
@@ -58,13 +58,16 @@ exports.parseTopojson = (stateMap, topology) => {
 
 exports.setupEventHandlers = (stateMap) => {
     const targets = $('.actionmap-view-region');
+    
     const hoverHtmlProvider = (elem) => {
         const countyName = elem.attr('data-county-name');
         return `${countyName}, ${stateMap.state.symbol}`;
     };
     const clickCallback = (elem) => {
         const countyFipsCode = elem.attr('data-county-fips-code');
-        window.location.href = `/state/${stateMap.state.symbol}/county/${countyFipsCode}`;
+        const countyName = elem.attr('data-county-name');
+        
+        window.location.href = `/search?address=${countyName},${stateMap.state.symbol}`;        
     };
     mapUtils.handleMapMouseEvents(targets, hoverHtmlProvider, clickCallback);
 };


### PR DESCRIPTION
Changed the URL that user gets redirected to on clicking county, so now instead of highlighting the selected county, user is redirected to page with all representatives from county.